### PR TITLE
Make the API parameter optional, because it causes Diffbot to waste t…

### DIFF
--- a/lib/diffbot/api_client/bot.rb
+++ b/lib/diffbot/api_client/bot.rb
@@ -9,9 +9,9 @@ module Diffbot
       # @param options [Hash]
       def initialize client, options = {}
         @api = options.delete(:api)
-        raise ArgumentError.new("client should be an instance of Diffbot::APIClient::GenericAPI") unless @api.is_a?(Diffbot::APIClient::GenericAPI)
+        raise ArgumentError.new("client should be an instance of Diffbot::APIClient::GenericAPI") unless @api.nil? || @api.is_a?(Diffbot::APIClient::GenericAPI)
 
-        options[:apiUrl] = @api.full_url
+        options[:apiUrl] = @api.full_url if @api
 
         raise ArgumentError.new("client should be an instance of Diffbot::APIClient") unless client.is_a?(Diffbot::APIClient)
         @client = client
@@ -33,6 +33,7 @@ module Diffbot
       #
       # @return [Hash]
       def details
+        return @details if @details
         post
       end
 

--- a/lib/diffbot/api_client/bulk.rb
+++ b/lib/diffbot/api_client/bulk.rb
@@ -11,7 +11,7 @@ module Diffbot
       def initialize client, options = {}
         super(client, options)
 
-        post(parse_params(options))
+        @details = post(parse_params(options))
       end
 
       # Return request path


### PR DESCRIPTION
…ime on large jobs, and prevent sending the same request twice when getting details.